### PR TITLE
Rename project to kinto.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kinto.js
 
-[![Build Status](https://travis-ci.org/mozilla-services/cliquetis.svg?branch=master)](https://travis-ci.org/mozilla-services/cliquetis) [![Coverage Status](https://coveralls.io/repos/mozilla-services/cliquetis/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/cliquetis?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![Coverage Status](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master)
 
 A JavaScript client for [Kinto](https://kinto.readthedocs.org/).

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,5 +1,5 @@
 function main() {
-  var db = new Cliquetis({
+  var db = new Kinto({
     remote: "https://kinto.dev.mozaws.net/v1",
     headers: {Authorization: "Basic " + btoa("user:pass")}
   });

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Cliquetis demo</title>
+  <title>Kinto.js demo</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 <body>
@@ -37,7 +37,7 @@
       </li>
     </template>
   </div>
-  <script src="cliquetis.dev.js"></script>
+  <script src="kinto.dev.js"></script>
   <script src="demo.js"></script>
 </body>
 </html>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,9 @@
 # API documentation
 
-## The `Cliquetis` constructor
+## The `Kinto` constructor
 
 ```js
-const db = new Cliquetis(options);
+const db = new Kinto(options);
 ```
 
 `options` is an object defining the following option values:
@@ -215,7 +215,7 @@ The `sync()` method accepts a `strategy` option, which itself accepts the follow
 - `Collection.strategy.SERVER_WINS`: Server data will be preserved;
 - `Collection.strategy.CLIENT_WINS`: Client data will be preserved.
 
-You can override default options by passing `#sync()` a new `options` object; Cliquetis will merge these new values with the default ones:
+You can override default options by passing `#sync()` a new `options` object; Kinto will merge these new values with the default ones:
 
 ```js
 articles.sync({

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,13 +1,13 @@
-# Hacking on Cliquetis
+# Hacking on Kinto.js
 
-Hacking on Cliquetis requires to setup a [NodeJS v0.12x environment](https://nodejs.org/download/).
+Hacking on Kinto.js requires to setup a [NodeJS v0.12x environment](https://nodejs.org/download/).
 
 ## Installation
 
-Code is [hosted on Github](https://github.com/mozilla-services/cliquetis).
+Code is [hosted on Github](https://github.com/mozilla-services/kinto.js).
 
-    $ git co https://github.com/mozilla-services/cliquetis
-    $ cd cliquetis
+    $ git co https://github.com/mozilla-services/kinto.js
+    $ cd kinto.js
     $ npm install
 
 ## Tests
@@ -20,7 +20,7 @@ This will also run code coverage and send the report to [Coveralls](http://cover
     $ npm run test-cover      # runs tests, code coverage; doesn't send results
     $ npm run test-cover-html # runs tests, code coverage and opens a fancy html report
 
-Note that code coverage reports are also [browseable on Coveralls](https://coveralls.io/r/mozilla-services/cliquetis).
+Note that code coverage reports are also [browseable on Coveralls](https://coveralls.io/r/mozilla-services/kinto.js).
 
 ### TDD mode
 
@@ -40,14 +40,14 @@ You can also grep to run a subset of tests that way:
 
 This should have created the following assets:
 
--  `dist/cliquetis.dev.js`: Developement version, unminified, embedding source maps;
--  `dist/cliquetis.min.js`: Production version, minified, no source maps.
+-  `dist/kinto.dev.js`: Developement version, unminified, embedding source maps;
+-  `dist/kinto.min.js`: Production version, minified, no source maps.
 
 ## Updating docs
 
 Docs are written in [Markdown](http://daringfireball.net/projects/markdown/syntax) using [mkdocs](http://www.mkdocs.org/), and are hosted on [readthedocs](https://readthedocs.org/).
 
-Document sources are versionned in the Cliquetis repository, under the [docs/ directory](https://github.com/mozilla-services/cliquetis/tree/master/docs). Updates are automatically deployed when pushed to `origin/master`. That means the docs site is automatically updated everytime a PR lands.
+Document sources are versionned in the Kinto.js repository, under the [docs/ directory](https://github.com/mozilla-services/kinto.js/tree/master/docs). Updates are automatically deployed when pushed to `origin/master`. That means the docs site is automatically updated everytime a PR lands.
 
 To build docs locally, ensure mkdocs is [properly installed](http://www.mkdocs.org/#installation), then run:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Kinto.js [![](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/pip/badge/?version=latest)](http://kinto.js.readthedocs.org/)
+# Kinto.js [![](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
 
 > An offline-first JavaScript client for [Kinto](http://kinto.readthedocs.org/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Cliquetis [![](https://travis-ci.org/mozilla-services/cliquetis.svg?branch=master)](https://travis-ci.org/mozilla-services/cliquetis) [![](https://coveralls.io/repos/mozilla-services/cliquetis/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/cliquetis?branch=master) [![](https://readthedocs.org/projects/pip/badge/?version=latest)](http://cliquetis.readthedocs.org/)
+# Kinto.js [![](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/pip/badge/?version=latest)](http://kinto.js.readthedocs.org/)
 
 > An offline-first JavaScript client for [Kinto](http://kinto.readthedocs.org/).
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -4,7 +4,7 @@ We'll create a super simple offline-first, remotely synchronized todo list appli
 
 ![](images/final.png)
 
-The final demo code is [available](https://github.com/mozilla-services/cliquetis/tree/master/demo) in the Cliquetis repository.
+The final demo code is [available](https://github.com/mozilla-services/kinto.js/tree/master/demo) in the Kinto.js repository.
 
 > #### Notes
 >
@@ -21,7 +21,7 @@ First, let's create a simple HTML file for our demo app, in an `index.html` file
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Cliquetis demo</title>
+  <title>Kinto.js demo</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 <body>
@@ -36,7 +36,7 @@ First, let's create a simple HTML file for our demo app, in an `index.html` file
     <hr>
     <ul id="tasks" class="list-group"></ul>
   </div>
-  <script src="https://raw.githubusercontent.com/mozilla-services/cliquetis/master/dist/cliquetis.min.js"></script>
+  <script src="https://raw.githubusercontent.com/mozilla-services/kinto.js/master/dist/kinto.min.js"></script>
   <script src="demo.js"></script>
 </body>
 </html>
@@ -46,7 +46,7 @@ For now, our `demo.js` file content is simply:
 
 ```js
 function main() {
-  var db = new Cliquetis({remote: "https://kinto.dev.mozaws.net/v0"});
+  var db = new Kinto({remote: "https://kinto.dev.mozaws.net/v0"});
   var tasks = db.collection("tasks");
 }
 
@@ -57,14 +57,14 @@ window.addEventListener("DOMContentLoaded", main);
 > #### Notes
 >
 > - For convenience, we're using a mozilla-hosted version of Kinto at `https://kinto.dev.mozaws.net/v0`; **data pushed to this instance are reset everyday**;
-> - You'll need to serve this page over HTTP, for Cliquetis to work. To do so, you can use node's [http-server](https://github.com/indexzero/http-server), Python's [SimpleHTTPServer](https://docs.python.org/2/library/simplehttpserver.html) or whatever Web server you like.
+> - You'll need to serve this page over HTTP, for Kinto.js to work. To do so, you can use node's [http-server](https://github.com/indexzero/http-server), Python's [SimpleHTTPServer](https://docs.python.org/2/library/simplehttpserver.html) or whatever Web server you like.
 
 For example, if you're using http-server:
 
     $ pwd
-    /home/niko/cliquetis-tutorial
+    /home/niko/kinto.js-tutorial
     $ npm install -g http-server
-    $ http-server /home/niko/cliquetis-tutorial
+    $ http-server /home/niko/kinto.js-tutorial
 
 And that's it. You should see something like this on `http://localhost:3000`:
 
@@ -76,7 +76,7 @@ We want to listen to form submission events to add tasks into our local database
 
 ```js
 function main() {
-  var db = new Cliquetis({remote: "https://kinto.dev.mozaws.net/v0"});
+  var db = new Kinto({remote: "https://kinto.dev.mozaws.net/v0"});
   var tasks = db.collection("tasks");
 
   document.getElementById("form")
@@ -117,7 +117,7 @@ All that is great, though we badly want to render our list of tasks now. Let's d
 
 ```js
 function main() {
-  var db = new Cliquetis({remote: "https://kinto.dev.mozaws.net/v0"});
+  var db = new Kinto({remote: "https://kinto.dev.mozaws.net/v0"});
   var tasks = db.collection("tasks");
 
   document.getElementById("form")
@@ -183,7 +183,7 @@ Last, switch off your Internet connection, and try adding tasks. It still works,
 
 > #### Notes
 >
-> - The Cliquetis API heavily relies on [Promises](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise). Don't hesitate to [learn a bit more](http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html) about them before digging further into this tutorial.
+> - The Kinto.js API heavily relies on [Promises](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise). Don't hesitate to [learn a bit more](http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html) about them before digging further into this tutorial.
 
 
 ## Updating a task
@@ -328,10 +328,10 @@ document.getElementById("sync")
   });
 ```
 
-We're passing an `Authorization` header as an option to `#sync()`; that's because we're using Basic Auth mode for Kinto. We could alternatively have defined that authorization header in the `Cliquetis` constructor:
+We're passing an `Authorization` header as an option to `#sync()`; that's because we're using Basic Auth mode for Kinto. We could alternatively have defined that authorization header in the `Kinto` constructor:
 
 ```js
-var db = new Cliquetis({
+var db = new Kinto({
   remote: "https://kinto.dev.mozaws.net/v0",
   headers: {Authorization: "Basic " + btoa("user:pass")}
 });
@@ -506,4 +506,4 @@ We're using `#resolve()` to mark a conflict as resolved: it accepts a conflict o
 
 ## Now what?
 
-That's all folks. Now feel free to browse the [API documentation](api.md), report [an issue](https://github.com/mozilla-services/cliquetis/issues/new), learn how to [contribute](hacking.md), but most of all: have fun.
+That's all folks. Now feel free to browse the [API documentation](api.md), report [an issue](https://github.com/mozilla-services/kinto.js/issues/new), learn how to [contribute](hacking.md), but most of all: have fun.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Cliquetis documentation
+site_name: Kinto.js documentation
 pages:
 - Home: index.md
 - Tutorial: tutorial.md

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "cliquetis",
+  "name": "kinto",
   "version": "0.0.1",
   "description": "JavaScript client for Cliquet.",
   "main": "index.js",
   "scripts": {
     "demo": "npm run dist && http-server demo",
     "dist": "npm run dist-dev && npm run dist-prod",
-    "dist-dev": "browserify -s Cliquetis -x fake-indexeddb -d -e src/index.js -o dist/cliquetis.dev.js",
-    "dist-prod": "browserify -s Cliquetis -x fake-indexeddb -g uglifyify -e src/index.js -o dist/cliquetis.min.js",
+    "dist-dev": "browserify -s Kinto -x fake-indexeddb -d -e src/index.js -o dist/kinto.dev.js",
+    "dist-prod": "browserify -s Kinto -x fake-indexeddb -g uglifyify -e src/index.js -o dist/kinto.min.js",
     "tdd": "mocha -w --compilers js:babel/register test/*_test.js",
     "test": "npm run test-cover && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test-cover": "babel-node node_modules/.bin/isparta cover --report text --report lcovonly node_modules/.bin/_mocha",
     "test-cover-html": "babel-node node_modules/.bin/isparta cover --report html --report lcovonly node_modules/.bin/_mocha && open coverage/index.html",
     "test-nocover": "mocha --compilers js:babel/register test/*_test.js",
-    "watch": "watchify -s Cliquetis -x fake-indexeddb -d -e src/index.js -o dist/cliquetis.dev.js -v"
+    "watch": "watchify -s Kinto -x fake-indexeddb -d -e src/index.js -o dist/kinto.dev.js -v"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mozilla-services/cliquetis.git"
+    "url": "https://github.com/mozilla-services/kinto.js.git"
   },
   "keywords": [
     "sync",
@@ -28,7 +28,7 @@
   "author": "Nicolas Perriault <nperriault@mozilla.com>",
   "license": "MPL",
   "bugs": {
-    "url": "https://github.com/mozilla-services/cliquetis/issues"
+    "url": "https://github.com/mozilla-services/kinto.js/issues"
   },
   "browserify": {
     "transform": [
@@ -40,7 +40,7 @@
       ]
     ]
   },
-  "homepage": "https://github.com/mozilla-services/cliquetis",
+  "homepage": "https://github.com/mozilla-services/kinto.js",
   "devDependencies": {
     "babel": "^5.4.4",
     "babelify": "^6.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import Collection from "./collection";
 const DEFAULT_BUCKET_NAME = "default";
 
 
-export default class Cliquetis {
+export default class Kinto {
   constructor(options = {}) {
     this._options = options;
     this._collections = {};

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -12,8 +12,8 @@ chai.use(chaiAsPromised);
 chai.should();
 chai.config.includeStack = true;
 
-const TEST_BUCKET_NAME = "cliquetis-test";
-const TEST_COLLECTION_NAME = "cliquetis-test";
+const TEST_BUCKET_NAME = "kinto-test";
+const TEST_COLLECTION_NAME = "kinto-test";
 const FAKE_SERVER_URL = "http://fake-server/v0"
 
 describe("Collection", () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -5,22 +5,22 @@ import chaiAsPromised from "chai-as-promised";
 import sinon from "sinon";
 import { v4 as uuid4 } from "uuid";
 
-import Cliquetis from "../src";
+import Kinto from "../src";
 import Collection from "../src/collection";
 
 chai.use(chaiAsPromised);
 chai.should();
 chai.config.includeStack = true;
 
-const TEST_BUCKET_NAME = "cliquetis-test";
-const TEST_COLLECTION_NAME = "cliquetis-test";
+const TEST_BUCKET_NAME = "kinto-test";
+const TEST_COLLECTION_NAME = "kinto-test";
 const FAKE_SERVER_URL = "http://fake-server"
 
-describe("Cliquetis", () => {
+describe("Kinto", () => {
   var sandbox;
 
   function testCollection() {
-    const db = new Cliquetis({
+    const db = new Kinto({
       bucket: TEST_BUCKET_NAME,
       bucketserverUrl: FAKE_SERVER_URL
     });
@@ -50,36 +50,36 @@ describe("Cliquetis", () => {
     })
 
     it("should use default bucket if not specified", () => {
-      const coll = new Cliquetis().collection(TEST_COLLECTION_NAME);
+      const coll = new Kinto().collection(TEST_COLLECTION_NAME);
       expect(coll.bucket).eql("default");
     })
 
     it("should cache collection instance", () => {
-      const db = new Cliquetis();
+      const db = new Kinto();
       expect(db.collection("a") == db.collection("a")).eql(true);
     });
 
     it("should reject on missing collection name", () => {
-      expect(() => new Cliquetis().collection())
+      expect(() => new Kinto().collection())
         .to.Throw(Error, /missing collection name/);
     });
 
     it("should setup the Api cient using default server URL", () => {
-      const db = new Cliquetis();
+      const db = new Kinto();
       const coll = db.collection("plop");
 
       expect(coll.api.remote).eql("http://0.0.0.0:8888/v0");
     });
 
     it("should setup the Api cient using provided server URL", () => {
-      const db = new Cliquetis({remote: "http://1.2.3.4:1234/v1"});
+      const db = new Kinto({remote: "http://1.2.3.4:1234/v1"});
       const coll = db.collection("plop");
 
       expect(coll.api.remote).eql("http://1.2.3.4:1234/v1");
     });
 
     it("should pass option headers to the api", () => {
-      const db = new Cliquetis({remote: "http://1.2.3.4:1234/v1", headers: {
+      const db = new Kinto({remote: "http://1.2.3.4:1234/v1", headers: {
         Authorization: "Basic plop"
       }});
       const coll = db.collection("plop");


### PR DESCRIPTION
There's been some confusion around the scope of Cliquetis, which in its current form is much more of a Kinto client than a Cliquet one. We should rename the project to reflect the situation and avoid creating more confusion.