### PR TITLE
Adding the documentation badge in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kinto.js
 
-[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![Coverage Status](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![Coverage Status](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
 
 A JavaScript client for [Kinto](https://kinto.readthedocs.org/).


### PR DESCRIPTION
Test:

[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![Coverage Status](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)