### PR TITLE
Refs #74 - Removed coverage from continuous integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kinto.js
 
-[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![Coverage Status](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
+[![Build Status](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
 
 A JavaScript client for [Kinto](https://kinto.readthedocs.org/).

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -14,13 +14,11 @@ Code is [hosted on Github](https://github.com/mozilla-services/kinto.js).
 
     $ npm test
 
-This will also run code coverage and send the report to [Coveralls](http://coveralls.io/). Alternatives:
+Code coverage reporting:
 
-    $ npm run test-nocover    # runs tests skipping code coverage
-    $ npm run test-cover      # runs tests, code coverage; doesn't send results
-    $ npm run test-cover-html # runs tests, code coverage and opens a fancy html report
-
-Note that code coverage reports are also [browseable on Coveralls](https://coveralls.io/r/mozilla-services/kinto.js).
+    $ npm run test-cover       # runs tests, code coverage
+    $ npm run test-cover-html  # runs tests, code coverage and generates a html report
+    $ open coverage/index.html # opens that fancy html report
 
 ### TDD mode
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Kinto.js [![](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://coveralls.io/repos/mozilla-services/kinto.js/badge.svg?branch=master)](https://coveralls.io/r/mozilla-services/kinto.js?branch=master) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
+# Kinto.js [![](https://travis-ci.org/mozilla-services/kinto.js.svg?branch=master)](https://travis-ci.org/mozilla-services/kinto.js) [![](https://readthedocs.org/projects/kintojs/badge/?version=latest)](http://kintojs.readthedocs.org/)
 
 > An offline-first JavaScript client for [Kinto](http://kinto.readthedocs.org/).
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist-dev": "browserify -s Kinto -x fake-indexeddb -d -e src/index.js -o dist/kinto.dev.js && cp dist/kinto.dev.js demo/",
     "dist-prod": "browserify -s Kinto -x fake-indexeddb -g uglifyify -e src/index.js -o dist/kinto.min.js && cp dist/kinto.min.js demo/",
     "tdd": "mocha -w --compilers js:babel/register test/*_test.js",
-    "test": "npm run test-cover && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test": "npm run test-nocover",
     "test-cover": "babel-node node_modules/.bin/isparta cover --report text $npm_package_config_ISPARTA_OPTS node_modules/.bin/_mocha",
     "test-cover-html": "babel-node node_modules/.bin/isparta cover --report html $npm_package_config_ISPARTA_OPTS node_modules/.bin/_mocha && open coverage/index.html",
     "test-nocover": "mocha --compilers js:babel/register test/*_test.js",


### PR DESCRIPTION
After speding a little while trying to come with a patch for [isparta](https://github.com/douglasduteil/isparta) to stop marking command results are okay [while they were actually failing](https://github.com/douglasduteil/isparta/issues/48), I decided we should simply drop coverage support from our continous integration process.

We shall abviously consider readding support for this if the issue is fixed someday.