### PR TITLE
Enable CORS

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -43,6 +43,7 @@ export default class HTTP {
     var response, status, statusText, headers;
     // Ensure default request headers are always set
     options.headers = Object.assign({}, HTTP.DEFAULT_REQUEST_HEADERS, options.headers);
+    options.mode = "cors";
     return fetch(url, options)
       .then(res => {
         response = res;


### PR DESCRIPTION
On FxOS we enforce the same origin policy for packaged apps, so we need to enable CORS to make kinto.js work.

If you think that it's not acceptable to enable CORS by default for every request, we can make the distinction checking if we are on a FxOS device and the requester is an app: origin (although this last part is supposed to change in the future in favor of http(s) origins)